### PR TITLE
Escaping special characters in requests that break the XML

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,8 @@ Description: RDatastream is a R interface to the Thomson Dataworks Enterprise
 License: MIT
 Imports:
     XML,
-    RCurl
+    RCurl,
+    htmltools
 Depends:
     R (>= 2.14)
 Collate:

--- a/R/ds.R
+++ b/R/ds.R
@@ -19,6 +19,9 @@
 #' @param source default "Datastream", useful if you want to access another
 #'   Dataworks Enterprise data source. You can obtain the list of sources
 #'   you have access to by using the dsSources() function in this package.
+#' @param htmlEscape boolean whether the provided parameters should be html 
+#'   escaped (ie. & replaced by &amp;). Defaults to FALSE to maintain 
+#'   backwards compatibility where people provide already escaped strings
 #' @return matrix with the returned data, columns being individual requests
 #'   and rows "Source", "Instrument", "StatusType", "StatusCode", 
 #'   "StatusMessage", "Fields" and "Data".
@@ -37,7 +40,7 @@
 ds <- function(user, securities=NULL, fields=NULL, 
                date=NULL, fromDate=NULL, toDate=NULL,
                period="D", requests=NULL, asDataFrame=TRUE,
-               source="Datastream") {
+               source="Datastream", htmlEscape=FALSE) {
   wsdl <- "http://dataworks.thomson.com/Dataworks/Enterprise/1.0/webServiceClient.asmx"
   xmlns <- "http://xml.thomson.com/financial/v1/tools/distribution/dataworks/enterprise/2003-07/"
   
@@ -59,6 +62,11 @@ ds <- function(user, securities=NULL, fields=NULL,
       }
       requests <- paste(requests, "~", period, sep="")
     }
+  }
+  
+  if (htmlEscape) {
+    # Will only affect special characters (like &, <, >) in symbol/series names
+    requests <- htmltools::htmlEscape(requests)
   }
   
   # SOAP headers

--- a/man/ds.Rd
+++ b/man/ds.Rd
@@ -5,7 +5,7 @@
   ds(user, securities = NULL, fields = NULL, date = NULL,
     fromDate = NULL, toDate = NULL, period = "D",
     requests = NULL, asDataFrame = TRUE,
-    source = "Datastream")
+    source = "Datastream", htmlEscape=FALSE)
 }
 \arguments{
   \item{user}{list with values username and password.}
@@ -38,6 +38,11 @@
   access another Dataworks Enterprise data source. You can
   obtain the list of sources you have access to by using
   the dsSources() function in this package.}
+  
+  \item{htmlEscape}{boolean whether the provided parameters 
+  should be html escaped (ie. & replaced by &amp;). 
+  Defaults to FALSE to maintain backwards compatibility 
+  where people provide already escaped strings}
 }
 \value{
   matrix with the returned data, columns being individual


### PR DESCRIPTION
Doing that conditionally on a parameter to maintain backwards compatibility where already escaped strings are provided. This resolves #3 without introducing breaking changes.